### PR TITLE
Enable oplog on dev mongodb instances

### DIFF
--- a/files/init_oplog
+++ b/files/init_oplog
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+#
+# Start populating the Mongo oplog (replication log) on the local instance.
+
+set -e
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $(basename $0) PORT" >&2
+  exit 1
+fi
+
+PORT=$1
+
+# If replication has never been configured before on this instance,
+# rs.initiate is needed to start it.
+# If it has previously been configured, rs.reconfig(force=true) is needed to update it.
+# To make the overall operation idempotent, just run them both.
+mongo --port $PORT <<END_MONGO
+  conf = { _id: "rs0", members: [ { _id: 0, host: "127.0.0.1:$PORT" } ] }
+  rs.initiate(conf)
+  rs.reconfig(conf, {force: true})
+END_MONGO

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -54,4 +54,9 @@ class mongodb(
     service => $service,
     enable  => $enable,
   }
+
+  ~>
+  class { 'mongodb::oplog':
+    port => $port
+  }
 }

--- a/manifests/oplog.pp
+++ b/manifests/oplog.pp
@@ -1,0 +1,20 @@
+# Enable oplog on the Mongo instance.
+class mongodb::oplog(
+  $port
+) inherits mongodb::params {
+
+  $init_oplog_path = "${boxen::config::home}/bin/init_oplog"
+
+  file {
+    $init_oplog_path:
+      source => 'puppet:///modules/mongodb/init_oplog' ;
+  }
+  
+  ~>
+  exec { "init_oplog":
+    # Allow retries to allow some leeway for slow DB boot times.
+    command => "${init_oplog_path} ${port}",
+    tries => 3,
+    try_sleep => 5,
+  }
+}

--- a/templates/mongod.conf.erb
+++ b/templates/mongod.conf.erb
@@ -3,3 +3,6 @@ port    = <%= @port %>
 
 dbpath  = <%= @datadir %>
 logpath = <%= @logdir %>/mongodb.log
+
+replSet = rs0
+oplogSize = 100


### PR DESCRIPTION
To enable the oplog to match production, we need to configure a single-node
replicaset.
- Add lines to mongodb.conf telling the instance it's part of a replicaset
- Add an `init_oplog` script to initialise/force-update replication
  config on the local instance
- Run `init_oplog` as part of the standard mongo setup
